### PR TITLE
Bad References make the script stop; this helps

### DIFF
--- a/scripts/cleanup-maildir.py
+++ b/scripts/cleanup-maildir.py
@@ -166,7 +166,7 @@ class MaildirMessage(mailbox.MaildirMessage):
 
     def getReferences(self):
         references = self.get('References')
-        if references is None:
+        if not references:
             return []
         # remove commas between references before splitting
         references = re.sub(r'>\s*,\s*<', '> <', references).strip()


### PR DESCRIPTION
this refers to issue #3: bad references are not fetched by your if-statement (and also not from the split-statement) but fail the return-list.
This patch was created by a good friend and me since I love hat script and still want to use it ;)

Thanks for porting it to Python3.x!