### PR TITLE
Update cleanup-maildir.py: '\s' needs to be in a raw string

### DIFF
--- a/scripts/cleanup-maildir.py
+++ b/scripts/cleanup-maildir.py
@@ -170,7 +170,7 @@ class MaildirMessage(mailbox.MaildirMessage):
             return []
         # remove commas between references before splitting
         references = re.sub(r'>\s*,\s*<', '> <', references).strip()
-        return [mid for mid in re.split('\s+', references) if mid[0] == '<' and mid[-1] == '>']
+        return [mid for mid in re.split(r'\s+', references) if mid[0] == '<' and mid[-1] == '>']
 
     def getDateSent(self):
         """Get the time of sending from the Date header


### PR DESCRIPTION
'\s' is reported as an invalid sequence, needs to be in a raw string.